### PR TITLE
Updated .gitingore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-
 # History files
 .Rhistory
+.RData
 .Rproj.user
+.Ruserdata
+
+# macOS hidden file
+.DS_Store


### PR DESCRIPTION
Closes #7 

This PR updates the `.gitignore` file with more usual suspects, so that all we'll need them to add in the workshop is the FASTQ files.