### PR TITLE
Update link to workshop website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Reproducible Research Practices Workshop Exercises
 
-This repository holds materials and exercises for the [Reproducible Research Practices Workshop](https://github.com/AlexsLemonade/reproducible-research).
+This repository holds materials and exercises for the [Reproducible Research Practices Workshop](https://alexslemonade.github.io/reproducible-research/).
 
 The directory structure serves as an example of project organization that maintains a separation among data, code, and analytical results.


### PR DESCRIPTION
This PR updates the README link to point to the built workshop site instead of the workshop repo.